### PR TITLE
We forgot to import PermissionError.

### DIFF
--- a/rbbz/models.py
+++ b/rbbz/models.py
@@ -9,7 +9,7 @@ from django.contrib.sites.models import Site
 from django.db import models
 from djblets.siteconfig.models import SiteConfiguration
 from djblets.util.decorators import simple_decorator
-from reviewboard.reviews.errors import PublishError
+from reviewboard.reviews.errors import PermissionError, PublishError
 from reviewboard.reviews.signals import (review_request_publishing,
                                          review_publishing, reply_publishing)
 from reviewboard.site.urlresolvers import local_site_reverse


### PR DESCRIPTION
We didn't run into this because in local testing, publishing the
children didn't go wrong, so we never hit this path.
